### PR TITLE
Specific dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ currently **not** supported:
 
  - identity resolution (mapping `anon_id`s to `known_id`s) 
  - nested saved entities (e.g. cohorts within cohorts)
+ - unsaved custom properties
  - copying data views + settings
  - user invites
  - session/group keys/timezone and other global project settings

--- a/envSample
+++ b/envSample
@@ -1,10 +1,14 @@
-# this file should be called .env and be in the same directory you're running the command
-SOURCE_ACCT = '{{ my OLD project service account }}' 
-SOURCE_PASS = '{{ my OLD project service secret }}' 
-SOURCE_PROJECT = '{{ my OLD project id }}' 
-SOURCE_DATE = '{{ the date of first event in old project, eg... 04-30-2022 }}' 
-SOURCE_REGION = 'US' #optional if US... mandatory if 'EU'
-TARGET_ACCT = '{{ my NEW project service account }}' 
-TARGET_PASS = '{{ my NEW project secret }}' 
-TARGET_PROJECT = '{{ my NEW project id }}' 
-TARGET_REGION = 'EU'
+# this file should be called .env and be in the SAME DIRECTORY that you are running mp-migrate in
+
+SOURCE_ACCT = '' 		#REQ: the service account of your SOURCE project
+SOURCE_PASS = '' 		#REQ: the service account secret of your SOURCE project
+SOURCE_PROJECT = '' 	#REQ: the SOURCE project id
+SOURCE_DATE_START = '' 	#optional: if copying events - when to start MM-DD-YYYY
+SOURCE_DATE_END = ''	#optional: if copying events - when to end MM-DD-YYYY
+SOURCE_REGION = '' 		#optional: if US... mandatory if 'EU'
+SOURCE_DASH_ID = '' 	#optional: a dashboard id (or comma sep list of dashIds) to copy ONLY a single dashboard
+
+TARGET_ACCT = '' 		#REQ: the service account of your TARGET project
+TARGET_PASS = '' 		#REQ: the service account secret of your TARGET project
+TARGET_PROJECT = ''		#REQ: the TARGET project id
+TARGET_REGION = ''		#optional: if US... mandatory if 'EU'

--- a/index.js
+++ b/index.js
@@ -160,6 +160,13 @@ this script can COPY data (events + users) as well as saved entities (dashboard,
 		log(`querying dashboards metadata...`, null, true);
 		sourceDashes = await u.getAllDash(source);
 		log(`	... 👍 found ${u.comma(sourceDashes.length)} dashboards`);
+		if (source.dash_id.length > 0) {
+			sourceDashes = sourceDashes.filter((dash) => {
+				return source.dash_id.some((specifiedId) => {
+					return specifiedId === dash.id;
+				});
+			});
+		}
 
 		//for each dashboard, get metadata for every child report
 		log(`querying reports metadata...`, null, true);
@@ -189,7 +196,7 @@ this script can COPY data (events + users) as well as saved entities (dashboard,
 			return sum === 0;
 		});
 		if (sourceEmptyDashes.length > 0) {
-			log(`	... found ${u.comma(sourceEmptyDashes.length)} empty dashboards; (these will NOT be copied)`);
+			log(`	... 👍 found ${u.comma(sourceEmptyDashes.length)} empty dashboards; (these will NOT be copied)`);
 			sourceDashes = sourceDashes
 				.filter(dash => {
 					return !sourceEmptyDashes
@@ -214,7 +221,7 @@ this script can COPY data (events + users) as well as saved entities (dashboard,
 			const dependentCohorts = sourceCohorts.map(cohort => cohort.id).filter(cohortId => dependentReports.some(reportString => reportString.includes(cohortId)));
 			const dependentCustEvents = sourceCustEvents.map(custEvent => custEvent.id).filter(custEventId => dependentReports.some(reportString => reportString.includes(custEventId)));
 			const depedentCustProps = sourceCustProps.map(custProp => custProp.customPropertyId).filter(custPropId => dependentReports.some(reportString => reportString.includes(custPropId)));
-			log(`\t... found ${dependentCohorts.length} cohort(s), ${dependentCustEvents.length} custom event(s), & ${depedentCustProps.length} custom prop(s) which the dashboard(s) depend on`);
+			log(`\t... 👍 found ${dependentCohorts.length} cohort(s), ${dependentCustEvents.length} custom event(s), & ${depedentCustProps.length} custom prop(s)\n\twhich the dashboard(s) depend on`);
 			sourceCohorts = sourceCohorts.filter((cohort) => {
 				return dependentCohorts.some(cohortId => cohortId === cohort.id);
 			});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mp-migrate",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "migrate mixpanel reports from one project to another",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
it is now possible to specify a `SOURCE_DASH_ID` as a single dashboard Id or as a list of comma separated dashboard Ids in the `.env` file.

you can also do it in code with an array `[]` of  `dash_id`s in the `source`. 

adding this values instructs `mp-migrate` to **ONLY** copy specified dashboard(s) from `source` to `target`.

in addition to the specified dashboards any `cohorts`, `custom events`, or `custom properties` that the specified dashboards "depends on" will also be copied.

the result is... magical 🧙‍♂️
![dash notation](https://user-images.githubusercontent.com/3978760/197604658-ff15689c-f35c-4ae4-9a3e-81b077b5f8bf.png)
